### PR TITLE
Spacer element preventing selection of notes.

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -35,7 +35,7 @@
     #blackkeys { position: absolute; z-index: 2; padding-left: 10px; margin-left: 41px; width:806px; height: 0px;}
     .key { display:inline-block; }
     .black { background: black; width: 40px; height: 150px; margin: 0px 11px; border-bottom-right-radius: 5px; border-bottom-left-radius: 5px; }
-    .spacer { display:inline-block; width: 62px; height: 150px; }
+    .spacer { display:inline-block; width: 62px; height: 0; }
     .white { background: white; width: 60px; height: 250px; border: 1px solid black; border-bottom-right-radius: 5px; border-bottom-left-radius: 5px; }
     .pressed { background: gray }
     #githubnotice { width:910px; text-align: center; font-size: 14px; margin-top: 10px; font-weight: bold;}


### PR DESCRIPTION
I found that the .spacer span used in between the b/c & e/f notes prevented selection of these keys in the top area where the spacer overlapped the .key spans.
