### PR TITLE
Replace tremolo with vibrato

### DIFF
--- a/js/synth.js
+++ b/js/synth.js
@@ -496,12 +496,12 @@ function Voice( note, velocity ) {
 	this.modOsc1Gain = audioContext.createGain();
 	this.modOsc.connect( this.modOsc1Gain );
 	this.modOsc1Gain.gain.value = currentModOsc1/10;
-	this.modOsc1Gain.connect( this.osc1.frequency );	// tremolo
+	this.modOsc1Gain.connect( this.osc1.frequency );	// vibrato
 
 	this.modOsc2Gain = audioContext.createGain();
 	this.modOsc.connect( this.modOsc2Gain );
 	this.modOsc2Gain.gain.value = currentModOsc2/10;
-	this.modOsc2Gain.connect( this.osc2.frequency );	// tremolo
+	this.modOsc2Gain.connect( this.osc2.frequency );	// vibrato
 
 	// create the LP filter
 	this.filter1 = audioContext.createBiquadFilter();
@@ -524,8 +524,8 @@ function Voice( note, velocity ) {
 	this.modOsc.connect( this.modFilterGain );
 	this.modFilterGain.gain.value = currentFilterMod*24;
 //	console.log("modFilterGain=" + currentFilterMod*24);
-	this.modFilterGain.connect( this.filter1.detune );	// filter tremolo
-	this.modFilterGain.connect( this.filter2.detune );	// filter tremolo
+	this.modFilterGain.connect( this.filter1.detune );	// filter vibrato
+	this.modFilterGain.connect( this.filter2.detune );	// filter vibrato
 
 	// create the volume envelope
 	this.envelope = audioContext.createGain();

--- a/js/ui.js
+++ b/js/ui.js
@@ -109,8 +109,8 @@ function setupSynthUI() {
 	var mod = createSection( "mod", 10, 10, 87, 342 );
 	mod.appendChild( createDropdown( "modwave", "shape", 12, 15, ["sine","square", "saw", "triangle"], currentModWaveform, onUpdateModWaveform ))
 	mod.appendChild( createKnob( "mFreq", "freq", 80, 12, 65, 0, 10, currentModFrequency, "#c10087", onUpdateModFrequency ) );
-	mod.appendChild( createKnob( "modOsc1", "osc1 tremolo", 80, 12, 160, 0, 100, currentModOsc1, "#c10087", onUpdateModOsc1 ) );
-	mod.appendChild( createKnob( "modOsc2", "osc2 tremolo", 80, 12, 255, 0, 100, currentModOsc2, "#c10087", onUpdateModOsc2 ) );
+	mod.appendChild( createKnob( "modOsc1", "osc1 vibrato", 80, 12, 160, 0, 100, currentModOsc1, "#c10087", onUpdateModOsc1 ) );
+	mod.appendChild( createKnob( "modOsc2", "osc2 vibrato", 80, 12, 255, 0, 100, currentModOsc2, "#c10087", onUpdateModOsc2 ) );
 	synthBox.appendChild( mod );
 
 	var osc1 = createSection( "OSC1", 130, 10, 223, 160 );	


### PR DESCRIPTION
The tremolo label text should be vibrato (see #24). This is only a visual change.