### PR TITLE
fix audio and midi initialization failure on modern browsers

### DIFF
--- a/js/midi.js
+++ b/js/midi.js
@@ -90,12 +90,15 @@ function onMIDIStarted( midi ) {
 
 function onMIDISystemError( err ) {
   document.getElementById("synthbox").className = "error";
-  console.log( "MIDI not initialized - error encountered:" + err.code );
+  console.log( "MIDI not initialized - error encountered: " + err + " / " + err.code );
 }
 
 //init: start up MIDI
-window.addEventListener('load', function() {   
-  if (navigator.requestMIDIAccess)
-    navigator.requestMIDIAccess().then( onMIDIStarted, onMIDISystemError );
+function onClickMIDIInitializer() {
+    if (navigator.requestMIDIAccess)
+        navigator.requestMIDIAccess().then( onMIDIStarted, onMIDISystemError );
+    // remove the listener - we only need to initialize once
+    document.removeEventListener("click", onClickMIDIInitializer);
 
-});
+}
+document.addEventListener("click", onClickMIDIInitializer);

--- a/js/synth.js
+++ b/js/synth.js
@@ -843,4 +843,20 @@ if('serviceWorker' in navigator) {
            .register('./service-worker.js')  
            .then(function() { console.log('Service Worker Registered'); });  
 }
-window.onload=initAudio;
+
+function prepareInit() {
+    var pressKeyToInitText = document.createElement('div');
+    pressKeyToInitText.innerHTML = '<div style="text-align: center;"><font color="red" size="7">Click to initialize Audio and MIDI</font></div>';
+
+    function onClickAudioInitializer() {
+        document.getElementById('synthbox').removeChild(pressKeyToInitText);
+        initAudio();
+        // remove the listener - we only need to initialize once
+        document.removeEventListener("click", onClickAudioInitializer);
+    }
+
+    document.addEventListener("click", onClickAudioInitializer);
+    document.getElementById('synthbox').appendChild(pressKeyToInitText);
+}
+
+window.onload=prepareInit;


### PR DESCRIPTION
Modern browsers require audio / midi initialization to be originated by user input.

This is a simple fix that does initialization of audio and midi on the first click event, rather than automatically `onload`.

Fixes #29 